### PR TITLE
Migrate set-output to the new GITHUB_OUTPUT env var method

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ aws s3api head-object --bucket ${AWS_S3_BUCKET} --key ${FILE}
 # XXX: we are just checking the error code, but should check the result for a 404, and raise error in other cases
 if [ $? == 0 ]
 then
-  echo "::set-output name=exists::true"
+  echo "exists=true" >> $GITHUB_OUTPUT
 else
-  echo "::set-output name=exists::false"
+  echo "exists=false" >> $GITHUB_OUTPUT
 fi


### PR DESCRIPTION
We forked and implemented these changes sometime last year but the repo disappeared for some reason. This [PR](https://github.com/sunsama/sunsama/pull/7374) in our main repo was the only pointer to this change that we had left.